### PR TITLE
Use correct UUID prefix for tagset export

### DIFF
--- a/catma_py/catma.py
+++ b/catma_py/catma.py
@@ -57,11 +57,11 @@ def gettimestamp() -> str:
     return timestamp[:-8] + timestamp[-5:]
 
 
-def get_catma_uuid_as_str(provider) -> str:
+def get_catma_uuid_as_str(provider, prefix: str="CATMA") -> str:
     """
     :return: the uuid of the given provider as a CATMA uuid as str.
     """
-    return "CATMA_" + str(provider.uuid).upper()
+    return prefix + "_" + str(provider.uuid).upper()
 
 
 def get_xml_node_id(node: XML) -> str:
@@ -540,7 +540,7 @@ class TEIAnnotationWriter(object):
             fsddecl_el = XML.SubElement(
                 encodingdesc_el,
                 "fsdDecl",
-                {"xml:id": get_catma_uuid_as_str(tagset),
+                {"xml:id": get_catma_uuid_as_str(tagset, prefix="T"),
                  "n": tagset.name + " " + tagset.version})
             for tag in tagset.tags.values():
                 attr = {"xml:id": get_catma_uuid_as_str(tag),


### PR DESCRIPTION
Tagsets were previously also accepted but the did not follow the naming scheme in CATMA, accordingly merging with an existing tagset was not possible (as those generated with catma-py had different identifiers).

There are probably other instances of UUID prefix mismatches which this PR does not address.